### PR TITLE
Addition of a test description field

### DIFF
--- a/JUnit.xsd
+++ b/JUnit.xsd
@@ -124,6 +124,11 @@ Permission to waive conditions of this license may be requested from Windy Road 
 							<xs:documentation xml:lang="en">Full class name for the class the test method is in.</xs:documentation>
 						</xs:annotation>
 					</xs:attribute>
+					<xs:attribute name="description" type="xs:string" use="optional">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">A short description of the test, usually derived from the test docstring.</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
 					<xs:attribute name="time" type="xs:decimal" use="required">
 						<xs:annotation>
 							<xs:documentation xml:lang="en">Time taken (in seconds) to execute the test</xs:documentation>


### PR DESCRIPTION
It would be useful to have a "description" field available to allow putting details about what the test is doing (usually grabbed from the test method's docstring) to enable automated populating of a test management system from, for example, Jenkins
